### PR TITLE
feat: crpr fix

### DIFF
--- a/.github/workflows/create-main-pr.yml
+++ b/.github/workflows/create-main-pr.yml
@@ -10,6 +10,9 @@ jobs:
   create-pr:
     if: github.event.pull_request.merged == true # かつ、マージされた場合のみ
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Geminiくんじゃ直せないなぁ、Claudeじゃないとあかんかなぁ

なぜこれで直るのか
原因: GitHub Actions が動く際、デフォルトではセキュリティのために GITHUB_TOKEN の権限が絞られています。今回のエラーは「PR を作るための write 権限がないぞ」という GitHub 側からの拒絶です。

解決策: permissions で pull-requests: write を指定することで、このワークフロー実行中だけ GITHUB_TOKEN に PR 作成の権限が正式に付与されます。

これで再試行してください。認証エラーが消え、develop -> main の PR 作成処理が正常に叩かれるはずです。